### PR TITLE
[BE] 친구와 경기 생성 API 구현

### DIFF
--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/AllStarController.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/AllStarController.java
@@ -1,7 +1,9 @@
 package bbTan.my_baseball_all_star.controller;
 
+import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayCreateRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
+import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayCreateResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayResultResponse;
 import bbTan.my_baseball_all_star.service.AllStarFacadeService;
 import jakarta.validation.Valid;
@@ -25,5 +27,10 @@ public class AllStarController {
     @PostMapping("/plays/friend")
     public ResponseEntity<PlayResultResponse> friendPlay(@Valid @RequestBody FriendPlayRequest request) {
         return ResponseEntity.ok(allStarService.friendPlay(request));
+    }
+
+    @PostMapping("/teams")
+    public ResponseEntity<FriendPlayCreateResponse> createFriendPlay(@Valid @RequestBody FriendPlayCreateRequest request) {
+        return ResponseEntity.ok(allStarService.createFriendPlay(request));
     }
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/request/FriendPlayCreateRequest.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/request/FriendPlayCreateRequest.java
@@ -1,0 +1,11 @@
+package bbTan.my_baseball_all_star.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record FriendPlayCreateRequest(@NotBlank(message = "팀 이름은 필수입니다.") String teamName,
+                                      @NotNull(message = "선수 목록은 필수입니다.") List<Long> playerIds,
+                                      @NotBlank(message = "비밀번호는 필수입니다.") String password
+) {
+}

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayCreateResponse.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayCreateResponse.java
@@ -1,0 +1,4 @@
+package bbTan.my_baseball_all_star.controller.dto.response;
+
+public record FriendPlayCreateResponse(String teamUuid) {
+}

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/domain/PlayShare.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/domain/PlayShare.java
@@ -1,5 +1,7 @@
 package bbTan.my_baseball_all_star.domain;
 
+import bbTan.my_baseball_all_star.global.exception.AllStarException;
+import bbTan.my_baseball_all_star.global.exception.ExceptionCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -17,6 +20,9 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 public class PlayShare {
+
+    private static final int MIN_PASSWORD_LENGTH = 4;
+    private static final int MAX_PASSWORD_LENGTH = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +34,19 @@ public class PlayShare {
     private String url;
 
     private String password;
+
+    public PlayShare(Team team, String password) {
+        this.team = team;
+        this.url = UUID.randomUUID().toString();
+        validatePassword(password);
+        this.password = password;
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.length() < MIN_PASSWORD_LENGTH || password.length() > MAX_PASSWORD_LENGTH) {
+            throw new AllStarException(ExceptionCode.INVALID_PASSWORD);
+        }
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/global/exception/ExceptionCode.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/global/exception/ExceptionCode.java
@@ -26,7 +26,11 @@ public enum ExceptionCode {
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀을 찾을 수 없습니다."),
 
     // PlayResult
-    INVALID_RESULT_SCORE_SIZE(HttpStatus.BAD_REQUEST, "경기 결과는 반드시 두 팀에 대한 점수여야 합니다.")
+    INVALID_RESULT_SCORE_SIZE(HttpStatus.BAD_REQUEST, "경기 결과는 반드시 두 팀에 대한 점수여야 합니다."),
+
+    // PlayShare
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 4자 이상 10자 이하여야 합니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/repository/PlayShareRepository.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/repository/PlayShareRepository.java
@@ -1,0 +1,7 @@
+package bbTan.my_baseball_all_star.repository;
+
+import bbTan.my_baseball_all_star.domain.PlayShare;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayShareRepository extends JpaRepository<PlayShare, Long> {
+}

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/PlayShareService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/PlayShareService.java
@@ -1,0 +1,21 @@
+package bbTan.my_baseball_all_star.service;
+
+import bbTan.my_baseball_all_star.domain.PlayShare;
+import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.repository.PlayShareRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PlayShareService {
+
+    private final PlayShareRepository playShareRepository;
+
+    @Transactional
+    public String createShareUrl(Team team, String password) {
+        PlayShare playShare = playShareRepository.save(new PlayShare(team, password));
+        return playShare.getUrl();
+    }
+}

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/TeamPlayerService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/TeamPlayerService.java
@@ -1,12 +1,14 @@
 package bbTan.my_baseball_all_star.service;
 
 import bbTan.my_baseball_all_star.domain.Player;
+import bbTan.my_baseball_all_star.domain.Team;
 import bbTan.my_baseball_all_star.domain.TeamPlayer;
 import bbTan.my_baseball_all_star.repository.TeamPlayerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -20,4 +22,14 @@ public class TeamPlayerService {
                 .map(TeamPlayer::getPlayer)
                 .toList();
     }
+
+    @Transactional
+    public void createAll(Team team, List<Player> players) {
+        List<TeamPlayer> teamPlayers = players.stream()
+                .map(player -> new TeamPlayer(team, player))
+                .toList();
+
+        teamPlayerRepository.saveAll(teamPlayers);
+    }
+
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/TeamService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/TeamService.java
@@ -1,6 +1,7 @@
 package bbTan.my_baseball_all_star.service;
 
 import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.domain.TeamRoaster;
 import bbTan.my_baseball_all_star.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,5 +25,10 @@ public class TeamService {
             return;
         }
         teamRepository.incrementTotalCount(id);
+    }
+
+    @Transactional
+    public Team create(TeamRoaster teamRoaster) {
+        return teamRepository.save(new Team(teamRoaster.getName()));
     }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/controller/AllStarE2ETest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/controller/AllStarE2ETest.java
@@ -97,4 +97,48 @@ class AllStarE2ETest extends AcceptanceTest {
                 .statusCode(400);
     }
 
+    @DisplayName("친구 초대용 팀 생성 성공")
+    @Test
+    void createFriendPlay() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(AllStarRequestFixture.FRIEND_PLAY_CREATE_REQUEST())
+                .when().post("/teams")
+                .then().log().all()
+                .statusCode(200);
+    }
+
+    @DisplayName("친구 초대용 팀 생성 실패: 팀 이름이 null일 경우")
+    @Test
+    void createFriendPlay_teamNameNull_exception() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(AllStarRequestFixture.FRIEND_PLAY_CREATE_REQUEST_TEAM_NAME_NULL())
+                .when().post("/teams")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("친구 초대용 팀 생성 실패: 선수 목록이 비어 있을 경우")
+    @Test
+    void createFriendPlay_playersEmpty_exception() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(AllStarRequestFixture.FRIEND_PLAY_CREATE_REQUEST_PLAYERS_EMPTY())
+                .when().post("/teams")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("친구 초대용 팀 생성 실패: 비밀번호가 비어 있을 경우")
+    @Test
+    void createFriendPlay_passwordEmpty_exception() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(AllStarRequestFixture.FRIEND_PLAY_CREATE_REQUEST_PASSWORD_EMPTY())
+                .when().post("/teams")
+                .then().log().all()
+                .statusCode(400);
+    }
+
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/domain/PlayShareTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/domain/PlayShareTest.java
@@ -1,0 +1,72 @@
+package bbTan.my_baseball_all_star.domain;
+
+import bbTan.my_baseball_all_star.fixture.TeamFixture;
+import bbTan.my_baseball_all_star.global.exception.AllStarException;
+import bbTan.my_baseball_all_star.global.exception.ExceptionCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayShareTest {
+
+    @DisplayName("PlayShare 생성 성공")
+    @Test
+    void playShareConstructor() {
+        // given
+        Team team = TeamFixture.TEAM1();
+        String password = "123456";
+
+        // when
+        PlayShare playShare = new PlayShare(team, password);
+
+        // then
+        assertAll(
+                () -> assertThat(playShare.getTeam()).isEqualTo(team),
+                () -> assertThat(playShare.getPassword()).isEqualTo(password),
+                () -> assertThat(playShare.getUrl()).isNotNull()
+        );
+    }
+
+    @DisplayName("PlayShare 생성 실패 : 비밀번호 null인 경우")
+    @Test
+    void playShareConstructor_nullPassword_exception() {
+        // given
+        Team team = TeamFixture.TEAM1();
+        String password = null;
+
+        // when & then
+        assertThatThrownBy(() -> new PlayShare(team, password))
+                .isInstanceOf(AllStarException.class)
+                .hasMessageContaining(ExceptionCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @DisplayName("PlayShare 생성 실패 : 비밀번호 길이 부족인 경우")
+    @Test
+    void playShareConstructor_shortPassword_exception() {
+        // given
+        Team team = TeamFixture.TEAM1();
+        String password = "123";
+
+        // when & then
+        assertThatThrownBy(() -> new PlayShare(team, password))
+                .isInstanceOf(AllStarException.class)
+                .hasMessageContaining(ExceptionCode.INVALID_PASSWORD.getMessage());
+    }
+
+    @DisplayName("PlayShare 생성 실패 : 비밀번호 길이 초과인 경우")
+    @Test
+    void playShareConstructor_longPassword_exception() {
+        // given
+        Team team = TeamFixture.TEAM1();
+        String password = "12345678901"; // 11자
+
+        // when & then
+        assertThatThrownBy(() -> new PlayShare(team, password))
+                .isInstanceOf(AllStarException.class)
+                .hasMessageContaining(ExceptionCode.INVALID_PASSWORD.getMessage());
+    }
+
+}

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/fixture/AllStarRequestFixture.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/fixture/AllStarRequestFixture.java
@@ -1,8 +1,10 @@
 package bbTan.my_baseball_all_star.fixture;
 
+import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayCreateRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.TeamRequest;
+import java.util.Collections;
 import java.util.List;
 
 public class AllStarRequestFixture {
@@ -48,4 +50,21 @@ public class AllStarRequestFixture {
     public static FriendPlayRequest FRIEND_PLAY_REQUEST_AWAY_PLAYERS_EMPTY() {
         return new FriendPlayRequest(1L, TEAM_REQUEST_PLAYERS_EMPTY("away"));
     }
+
+    public static FriendPlayCreateRequest FRIEND_PLAY_CREATE_REQUEST() {
+        return new FriendPlayCreateRequest("team", List.of(1L,2L,3L,4L,5L,6L,7L,8L,9L,10L,11L,12L), "pw1234");
+    }
+
+    public static FriendPlayCreateRequest FRIEND_PLAY_CREATE_REQUEST_TEAM_NAME_NULL() {
+        return new FriendPlayCreateRequest(null, List.of(1L,2L,3L,4L,5L,6L,7L,8L,9L,10L,11L,12L), "pw1234");
+    }
+
+    public static FriendPlayCreateRequest FRIEND_PLAY_CREATE_REQUEST_PLAYERS_EMPTY() {
+        return new FriendPlayCreateRequest("TeamA", Collections.emptyList(), "pw1234");
+    }
+
+    public static FriendPlayCreateRequest FRIEND_PLAY_CREATE_REQUEST_PASSWORD_EMPTY() {
+        return new FriendPlayCreateRequest("TeamA", List.of(1L,2L,3L,4L,5L,6L,7L,8L,9L,10L,11L,12L), "");
+    }
+
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/AllStarFacadeServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/AllStarFacadeServiceTest.java
@@ -1,9 +1,11 @@
 package bbTan.my_baseball_all_star.service;
 
 import bbTan.my_baseball_all_star.IntegrationTestSupport;
+import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayCreateRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.TeamRequest;
+import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayCreateResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayResultResponse;
 import bbTan.my_baseball_all_star.repository.PlayerChoiceCountRepository;
 import bbTan.my_baseball_all_star.repository.PlayerRepository;
@@ -75,6 +77,26 @@ class AllStarFacadeServiceTest extends IntegrationTestSupport {
                 () -> assertThat(result.awayTeam().teamName()).isEqualTo("AwayTeam"),
                 () -> assertThat(result.homeTeam().teamScore()).isBetween(0, 20),
                 () -> assertThat(result.awayTeam().teamScore()).isBetween(0, 20)
+        );
+    }
+
+    @DisplayName("친구 초대용 경기 생성 성공")
+    @Test
+    void createFriendPlay() {
+        // given
+        List<Long> playerIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L);
+        String teamName = "MyTeam";
+        String password = "password";
+
+        FriendPlayCreateRequest request = new FriendPlayCreateRequest(teamName, playerIds, password);
+
+        // when
+        FriendPlayCreateResponse response = facadeService.createFriendPlay(request);
+
+        // then
+        assertAll(
+                () -> assertThat(response).isNotNull(),
+                () -> assertThat(response.teamUuid()).isNotBlank()
         );
     }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
@@ -1,0 +1,48 @@
+package bbTan.my_baseball_all_star.service;
+
+import bbTan.my_baseball_all_star.IntegrationTestSupport;
+import bbTan.my_baseball_all_star.domain.PlayShare;
+import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.fixture.TeamFixture;
+import bbTan.my_baseball_all_star.repository.PlayShareRepository;
+import bbTan.my_baseball_all_star.repository.TeamRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayShareServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private PlayShareService playShareService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private PlayShareRepository playShareRepository;
+
+    @DisplayName("공유 URL 생성 성공")
+    @Test
+    void createShareUrl() {
+        // given
+        Team team = teamRepository.save(TeamFixture.TEAM1());
+        String password = "1234";
+
+        // when
+        String url = playShareService.createShareUrl(team, password);
+
+        // then
+        List<PlayShare> saved = playShareRepository.findAll();
+        assertAll(
+                () -> assertThat(saved).hasSize(1),
+                () -> assertThat(saved.get(0).getTeam().getId()).isEqualTo(team.getId()),
+                () -> assertThat(saved.get(0).getPassword()).isEqualTo(password),
+                () -> assertThat(saved.get(0).getUrl()).isEqualTo(url)
+        );
+    }
+}

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/TeamPlayerServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/TeamPlayerServiceTest.java
@@ -63,4 +63,21 @@ class TeamPlayerServiceTest extends IntegrationTestSupport {
         // then
         assertThat(players).isEmpty();
     }
+
+    @DisplayName("팀과 선수 리스트로 TeamPlayer들을 생성 성공")
+    @Test
+    void createAll() {
+        // given
+        Team team = teamRepository.save(TeamFixture.TEAM1());
+        Player player1 = playerRepository.save(PlayerFixture.PLAYER1());
+        Player player2 = playerRepository.save(PlayerFixture.PLAYER2());
+        List<Player> players = List.of(player1, player2);
+
+        // when
+        teamPlayerService.createAll(team, players);
+
+        // then
+        List<TeamPlayer> teamPlayers = teamPlayerRepository.findByTeamId(team.getId());
+        assertThat(teamPlayers).hasSize(2);
+    }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/TeamServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/TeamServiceTest.java
@@ -2,11 +2,15 @@ package bbTan.my_baseball_all_star.service;
 
 import bbTan.my_baseball_all_star.IntegrationTestSupport;
 import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.domain.TeamRoaster;
 import bbTan.my_baseball_all_star.fixture.TeamFixture;
+import bbTan.my_baseball_all_star.fixture.TeamRoasterFixture;
 import bbTan.my_baseball_all_star.repository.TeamRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -66,6 +70,23 @@ class TeamServiceTest extends IntegrationTestSupport {
         assertAll(
                 () -> assertThat(updated.getTotalPlayCount()).isEqualTo(1),
                 () -> assertThat(updated.getWinPlayCount()).isEqualTo(0)
+        );
+    }
+
+    @DisplayName("팀 생성 성공")
+    @Test
+    void createTeam() {
+        // given
+        String teamName = "팀";
+        TeamRoaster teamRoaster = TeamRoasterFixture.VALID_ROSTER(teamName);
+
+        // when
+        Team created = teamService.create(teamRoaster);
+
+        // then
+        assertAll(
+                () -> assertThat(created.getId()).isNotNull(),
+                () -> assertThat(created.getName()).isEqualTo(teamName)
         );
     }
 }


### PR DESCRIPTION
## **PR**

### ✏ 이슈 번호
- #10 
---
### ✨ 작업 내용
- 친구와 경기를 위한 팀을 생성하고 공유 URL을 반환하는 기능을 구현하였습니다.
---

### ✨ 참고 사항
- 없음
---

### ⏰ 현재 버그
- 없음
---

