### PR TITLE
[BE] 친구와 경기 조회 API 구현

### DIFF
--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/AllStarController.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/AllStarController.java
@@ -4,14 +4,15 @@ import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayCreateRequest
 import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayCreateResponse;
+import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayTeamResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayResultResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayerResponse;
-import bbTan.my_baseball_all_star.domain.Player;
 import bbTan.my_baseball_all_star.service.AllStarFacadeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,5 +43,10 @@ public class AllStarController {
     @PostMapping("/teams")
     public ResponseEntity<FriendPlayCreateResponse> createFriendPlay(@Valid @RequestBody FriendPlayCreateRequest request) {
         return ResponseEntity.ok(allStarService.createFriendPlay(request));
+    }
+
+    @GetMapping("/teams/{team-uuid}")
+    public ResponseEntity<FriendPlayTeamResponse> readFriendPlayTeam(@PathVariable("team-uuid") String teamUrl) {
+        return ResponseEntity.ok(allStarService.readFriendPlayTeam(teamUrl));
     }
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayTeamResponse.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayTeamResponse.java
@@ -1,0 +1,4 @@
+package bbTan.my_baseball_all_star.controller.dto.response;
+
+public record FriendPlayTeamResponse(Long teamId, String teamName) {
+}

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/global/exception/ExceptionCode.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/global/exception/ExceptionCode.java
@@ -32,7 +32,8 @@ public enum ExceptionCode {
     INVALID_PLAYER_SCORE(HttpStatus.BAD_REQUEST, "유효하지 않은 점수 결과입니다"),
 
     // PlayShare
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 4자 이상 10자 이하여야 합니다.")
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 4자 이상 10자 이하여야 합니다."),
+    TEAM_URL_NOT_FOUND(HttpStatus.BAD_REQUEST, "URL에 해당하는 팀을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/repository/PlayShareRepository.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/repository/PlayShareRepository.java
@@ -2,6 +2,9 @@ package bbTan.my_baseball_all_star.repository;
 
 import bbTan.my_baseball_all_star.domain.PlayShare;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface PlayShareRepository extends JpaRepository<PlayShare, Long> {
+
+    Optional<PlayShare> findByUrl(String url);
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/AllStarFacadeService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/AllStarFacadeService.java
@@ -5,6 +5,7 @@ import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.TeamRequest;
 import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayCreateResponse;
+import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayTeamResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayResultResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayerResponse;
 import bbTan.my_baseball_all_star.domain.Player;
@@ -82,9 +83,15 @@ public class AllStarFacadeService {
         return new TeamRoaster(team.getName(), players, playerChoiceCounts);
     }
 
-    public List<Integer> play(TeamRoaster home, TeamRoaster away) {
+    private List<Integer> play(TeamRoaster home, TeamRoaster away) {
         Integer homeTeamScore = TeamScoreCalculator.calculate(home);
         Integer awayTeamScore = TeamScoreCalculator.calculate(away);
         return List.of(homeTeamScore, awayTeamScore);
+    }
+
+    @Transactional(readOnly = true)
+    public FriendPlayTeamResponse readFriendPlayTeam(String teamUrl) {
+        Team team = playShareService.readTeamByUrl(teamUrl);
+        return new FriendPlayTeamResponse(team.getId(), team.getName());
     }
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/PlayShareService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/PlayShareService.java
@@ -2,10 +2,13 @@ package bbTan.my_baseball_all_star.service;
 
 import bbTan.my_baseball_all_star.domain.PlayShare;
 import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.global.exception.AllStarException;
+import bbTan.my_baseball_all_star.global.exception.ExceptionCode;
 import bbTan.my_baseball_all_star.repository.PlayShareRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -17,5 +20,14 @@ public class PlayShareService {
     public String createShareUrl(Team team, String password) {
         PlayShare playShare = playShareRepository.save(new PlayShare(team, password));
         return playShare.getUrl();
+    }
+
+    @Transactional(readOnly = true)
+    public Team readTeamByUrl(String teamUrl) {
+        Optional<PlayShare> playShare = playShareRepository.findByUrl(teamUrl);
+        if (playShare.isEmpty()) {
+            throw new AllStarException(ExceptionCode.TEAM_URL_NOT_FOUND);
+        }
+        return playShare.get().getTeam();
     }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/IntegrationTestSupport.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/IntegrationTestSupport.java
@@ -4,9 +4,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Sql(scripts = {"/schema-test.sql", "/data-test.sql"})
+@Transactional
 public abstract class IntegrationTestSupport {
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/IntegrationTestSupport.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/IntegrationTestSupport.java
@@ -9,6 +9,5 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Sql(scripts = {"/schema-test.sql", "/data-test.sql"})
-@Transactional
 public abstract class IntegrationTestSupport {
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/controller/AllStarE2ETest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/controller/AllStarE2ETest.java
@@ -7,6 +7,8 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.Matchers.notNullValue;
+
 class AllStarE2ETest extends AcceptanceTest {
 
     @DisplayName("홀로 경기 성공")
@@ -141,4 +143,28 @@ class AllStarE2ETest extends AcceptanceTest {
                 .statusCode(400);
     }
 
+    @DisplayName("친구 초대용 팀 조회 성공")
+    @Test
+    void readFriendPlayTeam() {
+        // given
+        String teamUuid = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(AllStarRequestFixture.FRIEND_PLAY_CREATE_REQUEST())
+                .when().post("/teams")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .body()
+                .jsonPath()
+                .getString("teamUuid");
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/teams/{team-uuid}", teamUuid)
+                .then().log().all()
+                .statusCode(200)
+                .body("teamId", notNullValue())
+                .body("teamName", notNullValue());
+    }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/AllStarFacadeServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/AllStarFacadeServiceTest.java
@@ -6,9 +6,15 @@ import bbTan.my_baseball_all_star.controller.dto.request.FriendPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.SoloPlayRequest;
 import bbTan.my_baseball_all_star.controller.dto.request.TeamRequest;
 import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayCreateResponse;
+import bbTan.my_baseball_all_star.controller.dto.response.FriendPlayTeamResponse;
 import bbTan.my_baseball_all_star.controller.dto.response.PlayResultResponse;
+import bbTan.my_baseball_all_star.domain.PlayShare;
+import bbTan.my_baseball_all_star.domain.Team;
+import bbTan.my_baseball_all_star.fixture.TeamFixture;
+import bbTan.my_baseball_all_star.repository.PlayShareRepository;
 import bbTan.my_baseball_all_star.repository.PlayerChoiceCountRepository;
 import bbTan.my_baseball_all_star.repository.PlayerRepository;
+import bbTan.my_baseball_all_star.repository.TeamRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,13 +29,19 @@ class AllStarFacadeServiceTest extends IntegrationTestSupport {
     AllStarFacadeService allStarFacadeService;
 
     @Autowired
+    private AllStarFacadeService facadeService;
+
+    @Autowired
     PlayerRepository playerRepository;
 
     @Autowired
     PlayerChoiceCountRepository playerChoiceCountRepository;
 
     @Autowired
-    private AllStarFacadeService facadeService;
+    TeamRepository teamRepository;
+
+    @Autowired
+    PlayShareRepository playShareRepository;
 
     @Test
     @DisplayName("홀로 경기 성공")
@@ -99,4 +111,24 @@ class AllStarFacadeServiceTest extends IntegrationTestSupport {
                 () -> assertThat(response.teamUuid()).isNotBlank()
         );
     }
+
+    @DisplayName("친구 초대용 경기 팀 조회 성공")
+    @Test
+    void readFriendPlayTeam() {
+        // given
+        Team team = teamRepository.save(TeamFixture.TEAM1());
+        PlayShare playShare = playShareRepository.save(new PlayShare(team, "1234"));
+        String teamUrl = playShare.getUrl();
+
+        // when
+        FriendPlayTeamResponse response = facadeService.readFriendPlayTeam(teamUrl);
+
+        // then
+        assertAll(
+                () -> assertThat(response).isNotNull(),
+                () -> assertThat(response.teamId()).isEqualTo(team.getId()),
+                () -> assertThat(response.teamName()).isEqualTo(team.getName())
+        );
+    }
+
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
@@ -4,16 +4,18 @@ import bbTan.my_baseball_all_star.IntegrationTestSupport;
 import bbTan.my_baseball_all_star.domain.PlayShare;
 import bbTan.my_baseball_all_star.domain.Team;
 import bbTan.my_baseball_all_star.fixture.TeamFixture;
+import bbTan.my_baseball_all_star.global.exception.AllStarException;
+import bbTan.my_baseball_all_star.global.exception.ExceptionCode;
 import bbTan.my_baseball_all_star.repository.PlayShareRepository;
 import bbTan.my_baseball_all_star.repository.TeamRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class PlayShareServiceTest extends IntegrationTestSupport {
 
@@ -44,5 +46,34 @@ class PlayShareServiceTest extends IntegrationTestSupport {
                 () -> assertThat(saved.get(0).getPassword()).isEqualTo(password),
                 () -> assertThat(saved.get(0).getUrl()).isEqualTo(url)
         );
+    }
+
+    @DisplayName("URL로 팀 조회 성공")
+    @Test
+    void readTeamByUrl() {
+        // given
+        Team team = teamRepository.save(TeamFixture.TEAM1());
+        PlayShare playShare = playShareRepository.save(new PlayShare(team, "password"));
+
+        // when
+        Team foundTeam = playShareService.readTeamByUrl(playShare.getUrl());
+
+        // then
+        assertAll(
+                () -> assertThat(foundTeam.getId()).isEqualTo(team.getId()),
+                () -> assertThat(foundTeam.getName()).isEqualTo(team.getName())
+        );
+    }
+
+    @DisplayName("URL로 팀 조회 실패 : 존재하지 않는 URL인 경우")
+    @Test
+    void readTeamByUrl_notFound_exception() {
+        // given
+        String nonExistentUrl = "non-existent-url";
+
+        // when & then
+        assertThatThrownBy(() -> playShareService.readTeamByUrl(nonExistentUrl))
+                .isInstanceOf(AllStarException.class)
+                .hasMessageContaining(ExceptionCode.TEAM_URL_NOT_FOUND.getMessage());
     }
 }

--- a/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
+++ b/my-baseball-all-star/src/test/java/bbTan/my_baseball_all_star/service/PlayShareServiceTest.java
@@ -11,6 +11,7 @@ import bbTan.my_baseball_all_star.repository.TeamRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +51,7 @@ class PlayShareServiceTest extends IntegrationTestSupport {
 
     @DisplayName("URL로 팀 조회 성공")
     @Test
+    @Transactional
     void readTeamByUrl() {
         // given
         Team team = teamRepository.save(TeamFixture.TEAM1());
@@ -67,6 +69,7 @@ class PlayShareServiceTest extends IntegrationTestSupport {
 
     @DisplayName("URL로 팀 조회 실패 : 존재하지 않는 URL인 경우")
     @Test
+    @Transactional
     void readTeamByUrl_notFound_exception() {
         // given
         String nonExistentUrl = "non-existent-url";


### PR DESCRIPTION
## **PR**

### ✏ 이슈 번호
- #16 
---
### ✨ 작업 내용
- 구가 공유해 준 링크에 접속하였을 때 친구의 home 팀에 대한 id, name 정보를 반환하는 API 구현
---

### ✨ 참고 사항
- 없음
---

### ⏰ 현재 버그
- 없음
---

