### PR TITLE
[BE] 친구와 경기 팀 조회 시 선수 정보도 포함

### DIFF
--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayTeamResponse.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/FriendPlayTeamResponse.java
@@ -1,4 +1,6 @@
 package bbTan.my_baseball_all_star.controller.dto.response;
 
-public record FriendPlayTeamResponse(Long teamId, String teamName) {
+import java.util.List;
+
+public record FriendPlayTeamResponse(Long teamId, String teamName, List<PlayerResponse> players) {
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/PlayerResponse.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/controller/dto/response/PlayerResponse.java
@@ -3,11 +3,9 @@ package bbTan.my_baseball_all_star.controller.dto.response;
 import bbTan.my_baseball_all_star.domain.Player;
 
 public record PlayerResponse (long id, String name, String dateOfBirth,
-                              String club, String position,
-                              Double score, String profileUrl) {
+                              String club, String position, String profileUrl) {
     public static PlayerResponse fromEntity(Player player) {
         return new PlayerResponse(player.getId(), player.getName(), player.getDateOfBirth().toString(),
-                player.getClub().getName(), player.getPosition().getName(),
-                player.getScore(), player.getProfileUrl());
+                player.getClub().getName(), player.getPosition().getName(), player.getProfileUrl());
     }
 }

--- a/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/AllStarFacadeService.java
+++ b/my-baseball-all-star/src/main/java/bbTan/my_baseball_all_star/service/AllStarFacadeService.java
@@ -116,7 +116,9 @@ public class AllStarFacadeService {
     @Transactional(readOnly = true)
     public FriendPlayTeamResponse readFriendPlayTeam(String teamUrl) {
         Team team = playShareService.readTeamByUrl(teamUrl);
-        return new FriendPlayTeamResponse(team.getId(), team.getName());
+        List<PlayerResponse> players = teamPlayerService.readByTeamId(team.getId())
+                .stream().map(PlayerResponse::fromEntity).toList();
+        return new FriendPlayTeamResponse(team.getId(), team.getName(), players);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## **PR**

### ✏ 이슈 번호
- #69 
---
### ✨ 작업 내용
- 친구 팀 조회 응답값에서 선수 정보를 추가하였습니다.
---

### ✨ 참고 사항
- 없음
---

### ⏰ 현재 버그
- 없음
---

