### PR TITLE
[BE] 서버 운영 환경 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,9 +33,11 @@ jobs:
       - name: Write application.yml
         env:
           APPLICATION_YML: ${{ secrets.APPLICATION_YML }}
+          APPLICATION_PROD_YML: ${{ secrets.APPLICATION_PROD_YML }}
           APPLICATION_TEST_YML: ${{ secrets.APPLICATION_TEST_YML }}
         run: |
           echo "${APPLICATION_YML}" > my-baseball-all-star/src/main/resources/application.yml
+          echo "${APPLICATION_PROD_YML}" > my-baseball-all-star/src/main/resources/application-prod.yml
           echo "${APPLICATION_TEST_YML}" > my-baseball-all-star/src/test/resources/application-test.yml
 
       - name: Build with Gradle
@@ -66,4 +68,4 @@ jobs:
 
       - name: Start server
         run: |
-          sudo nohup java -jar -Duser.timezone=Asia/Seoul ./my-baseball-all-star/build/libs/*SNAPSHOT.jar &
+          sudo nohup java -jar -Dspring.profiles.active=prod -Duser.timezone=Asia/Seoul ./my-baseball-all-star/build/libs/*SNAPSHOT.jar &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,12 @@ jobs:
     - name: Write application.yml
       env:
         APPLICATION_YML: ${{ secrets.APPLICATION_YML }}
+        APPLICATION_LOCAL_YML: ${{ secrets.APPLICATION_LOCAL_YML }}
         APPLICATION_TEST_YML: ${{ secrets.APPLICATION_TEST_YML }}
       
       run: |
         echo "${APPLICATION_YML}" > src/test/resources/application.yml
+        echo "${APPLICATION_LOCAL_YML}" > src/test/resources/application-local.yml
         echo "${APPLICATION_TEST_YML}" > src/test/resources/application-test.yml
 
     - name: Build with Gradle

--- a/my-baseball-all-star/build.gradle
+++ b/my-baseball-all-star/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.retry:spring-retry'
 	implementation 'org.springframework:spring-aspects'
+	runtimeOnly 'com.h2database:h2'
 
 	//크롤링을 위한 셀레니움
 	implementation 'org.seleniumhq.selenium:selenium-java:4.34.0'


### PR DESCRIPTION
## **PR**

### ✏ 이슈 번호
- #74 
---
### ✨ 작업 내용
- prod.yml과 local.yml을 분리하였습니다.
- prod.yml : sql으로 init을 하지 않도록 변경
- local.yml : sql으로 init, h2 사용
- ci의 경우 local.yml 사용, cd의 경우 prod.yml 사용
---

### ✨ 참고 사항
- yml이 업데이트 되었습니다. 노션을 참고하여 바꿔 주세요!
---

### ⏰ 현재 버그
- 없음
---

